### PR TITLE
Mark mut which is really mut

### DIFF
--- a/magickwand/src/pixel.rs
+++ b/magickwand/src/pixel.rs
@@ -20,11 +20,11 @@ impl Pixel {
         Pixel { ptr }
     }
 
-    pub fn clear_pixel_wand(&self) {
+    pub fn clear_pixel_wand(&mut self) {
         unsafe { magickwand_bindgen::ClearPixelWand(self.ptr) };
     }
 
-    pub fn pixel_set_color(&self, color: &str) -> Result<(), error::ExceptionType> {
+    pub fn pixel_set_color(&mut self, color: &str) -> Result<(), error::ExceptionType> {
         let c_color = CString::new(color).expect("CString::new color");
         let status = unsafe { magickwand_bindgen::PixelSetColor(self.ptr, c_color.as_ptr()) };
 
@@ -36,7 +36,7 @@ impl Pixel {
     }
 
     /// the level of transparency: alpha 1.0 is fully opaque and 0.0 is fully transparent.
-    pub fn pixel_set_alpha(&self, alpha: f64) {
+    pub fn pixel_set_alpha(&mut self, alpha: f64) {
         unsafe { magickwand_bindgen::PixelSetAlpha(self.ptr, alpha) };
     }
 

--- a/magickwand/src/wand.rs
+++ b/magickwand/src/wand.rs
@@ -67,17 +67,17 @@ impl Wand {
         Wand { ptr }
     }
 
-    pub fn clear_magick_wand(&self) {
+    pub fn clear_magick_wand(&mut self) {
         unsafe { magickwand_bindgen::ClearMagickWand(self.ptr) };
     }
 
-    pub fn magick_reset_iterator(&self) {
+    pub fn magick_reset_iterator(&mut self) {
         unsafe {
             magickwand_bindgen::MagickResetIterator(self.ptr);
         }
     }
 
-    pub fn magick_read_image_file(&self, file: &File) -> Result<(), error::ExceptionType> {
+    pub fn magick_read_image_file(&mut self, file: &mut File) -> Result<(), error::ExceptionType> {
         let status = unsafe { magickwand_bindgen::MagickReadImageFile(self.ptr, file.ptr) };
 
         if status == MagickFalse {
@@ -87,7 +87,7 @@ impl Wand {
         }
     }
 
-    pub fn magick_write_image_file(&self, file: &File) -> Result<(), error::ExceptionType> {
+    pub fn magick_write_image_file(&mut self, file: &mut File) -> Result<(), error::ExceptionType> {
         let status = unsafe { magickwand_bindgen::MagickWriteImageFile(self.ptr, file.ptr) };
 
         if status == MagickFalse {
@@ -97,7 +97,10 @@ impl Wand {
         }
     }
 
-    pub fn magick_write_images_file(&self, file: &File) -> Result<(), error::ExceptionType> {
+    pub fn magick_write_images_file(
+        &mut self,
+        file: &mut File,
+    ) -> Result<(), error::ExceptionType> {
         let status = unsafe { magickwand_bindgen::MagickWriteImagesFile(self.ptr, file.ptr) };
 
         if status == MagickFalse {
@@ -108,7 +111,7 @@ impl Wand {
     }
 
     pub fn magick_set_image_background_color(
-        &self,
+        &mut self,
         pixel: &pixel::Pixel,
     ) -> Result<(), error::ExceptionType> {
         let status =
@@ -128,7 +131,7 @@ impl Wand {
     /// - `x`: the shadow x-offset.
     /// - `y`: the shadow y-offset.
     pub fn magick_shadow_image(
-        &self,
+        &mut self,
         alpha: f64,
         sigma: f64,
         x: std::os::raw::c_long,
@@ -144,7 +147,7 @@ impl Wand {
     }
 
     pub fn magick_composite_image(
-        &self,
+        &mut self,
         source: &Wand,
         operator: enums::CompositeOperator,
         x: std::os::raw::c_long,

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,7 +40,7 @@ async fn main() {
     }
 
     // wand to be taken by all the MagickWandy APIs
-    let wand = magickwand::Wand::new();
+    let mut wand = magickwand::Wand::new();
 
     // HTTP request client
     let client = reqwest::Client::new();
@@ -102,9 +102,9 @@ async fn main() {
         }
 
         {
-            let input_emoji = magickwand::File::new(&emoji_save_path.to_string_lossy(), "rb");
+            let mut input_emoji = magickwand::File::new(&emoji_save_path.to_string_lossy(), "rb");
 
-            if let Err(exception_type) = wand.magick_read_image_file(&input_emoji) {
+            if let Err(exception_type) = wand.magick_read_image_file(&mut input_emoji) {
                 eprintln!(
                     "magick_read_image_file {} failed: {}",
                     &emoji_save_path.display(),
@@ -117,9 +117,9 @@ async fn main() {
         }
 
         {
-            let output_emoji = magickwand::File::new(&emoji_save_path.to_string_lossy(), "wb");
+            let mut output_emoji = magickwand::File::new(&emoji_save_path.to_string_lossy(), "wb");
             // *images* to deal with gif animations
-            if let Err(exception_type) = wand.magick_write_images_file(&output_emoji) {
+            if let Err(exception_type) = wand.magick_write_images_file(&mut output_emoji) {
                 eprintln!(
                     "magick_write_images_file {} failed: {}",
                     &emoji_save_path.display(),


### PR DESCRIPTION
This PR has some experimental aspects.
Mapping `*mut` to `&mut` on the boundary between C and Rust world we could benefit the Rust's borrowing rule which could not with the original raw interfaces, I think.